### PR TITLE
fixes json.decoder.JSONDecodeError

### DIFF
--- a/staking/consumer/token_stake_event_consumer.py
+++ b/staking/consumer/token_stake_event_consumer.py
@@ -41,7 +41,7 @@ class TokenStakeEventConsumer(object):
 
     @staticmethod
     def _get_event_data(event):
-        return json.loads(event['data']['json_str'])
+        return eval(event['data']['json_str'])
 
     @staticmethod
     def _get_metadata_hash(metadata_uri):


### PR DESCRIPTION
fixes `json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes`